### PR TITLE
[ADD] New module extending partnerinfo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ python:
   - "2.7"
 
 env:
-  - VERSION="8.0" ODOO_REPO="odoo/odoo"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB"
+  - VERSION="8.0" LINT_CHECK="1"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" OPTIONS="--test-commit" LINT_CHECK="0"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" OPTIONS="--test-commit" LINT_CHECK="0"
 
 virtualenv:
   system_site_packages: true
@@ -13,11 +14,12 @@ virtualenv:
 install:
   - sudo pip install unidecode
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - git clone https://github.com/odoomrp/odoomrp-wip ${HOME}/odoomrp-wip -b ${VERSION}
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
-  - travis_install_nightly ${VERSION}
+  - travis_install_nightly
 
 script:
-  - travis_run_tests ${VERSION}
+  - travis_run_tests
 
 after_success:
   coveralls

--- a/product_pricelist_partnerinfo/__init__.py
+++ b/product_pricelist_partnerinfo/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/product_pricelist_partnerinfo/__openerp__.py
+++ b/product_pricelist_partnerinfo/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    "name": "Product pricelist partnerinfo",
+    "version": "1.0",
+    "depends": [
+        "product",
+        "product_supplierinfo_for_customer",
+    ],
+    "author": "OdooMRP team",
+    "website": "http://www.odoomrp.com",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <ajuaristio@gmail.com>"
+    ],
+    "category": "Custom Module",
+    "summary": "",
+    "data": [
+        "views/pricelist_partnerinfo_view.xml",
+        "views/product_view.xml",
+    ],
+    "installable": True,
+}

--- a/product_pricelist_partnerinfo/models/__init__.py
+++ b/product_pricelist_partnerinfo/models/__init__.py
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import pricelist_partnerinfo
+from . import product

--- a/product_pricelist_partnerinfo/models/pricelist_partnerinfo.py
+++ b/product_pricelist_partnerinfo/models/pricelist_partnerinfo.py
@@ -1,0 +1,41 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class PricelistPartnerinfo(models.Model):
+    _inherit = 'pricelist.partnerinfo'
+
+    partner = fields.Many2one(
+        comodel_name='res.partner', string='Partner',
+        related='suppinfo_id.name', store=True)
+    type = fields.Selection(
+        string='Type', related='suppinfo_id.type', store=True)
+    product_tmpl_id = fields.Many2one(
+        comodel_name='product.template', string='Product Template',
+        related='suppinfo_id.product_tmpl_id', store=True)
+    product_name = fields.Char(
+        string='Product Name', related='suppinfo_id.product_name', store=True)
+    product_code = fields.Char(
+        string='Product Code', related='suppinfo_id.product_code', store=True)
+    sequence = fields.Integer(
+        string='Sequence', related='suppinfo_id.sequence')
+    company_id = fields.Many2one(
+        comodel_name='res.company', string='Company',
+        related='suppinfo_id.company_id')

--- a/product_pricelist_partnerinfo/models/product.py
+++ b/product_pricelist_partnerinfo/models/product.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.multi
+    def open_related_partnerinfo(self):
+        result = self._get_act_window_dict(
+            'product_pricelist_partnerinfo.pricelist_partnerinfo_action')
+        result['domain'] = "[('product_tmpl_id', 'in', " + str(self.ids) + ")]"
+        return result
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.multi
+    def open_related_partnerinfo(self):
+        self.ensure_one()
+        result = self.product_tmpl_id._get_act_window_dict(
+            'product_pricelist_partnerinfo.pricelist_partnerinfo_action')
+        result['domain'] = ("[('product_tmpl_id', '=', " +
+                            str(self.product_tmpl_id.id) + ")]")
+        return result

--- a/product_pricelist_partnerinfo/views/pricelist_partnerinfo_view.xml
+++ b/product_pricelist_partnerinfo/views/pricelist_partnerinfo_view.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="pricelist_partnerinfo_tree_view" model="ir.ui.view">
+            <field name="name">pricelist.partnerinfo.tree</field>
+            <field name="model">pricelist.partnerinfo</field>
+            <field name="arch" type="xml">
+                <tree string="Partnerinfo" editable="top">
+                    <field name="sequence" readonly="1" />
+                    <field name="name" />
+                    <field name="suppinfo_id" />
+                    <field name="min_quantity" />
+                    <field name="price" />
+                    <field name="type" invisible="1" />
+                    <field name="product_tmpl_id" readonly="1" />
+                    <field name="partner" readonly="1" />
+                    <field name="product_code" readonly="1" />
+                    <field name="product_name" readonly="1" />
+                    <field name="company_id" groups="base.group_multi_company"
+                        invisible="1" />
+                </tree>
+            </field>
+        </record>
+
+        <record id="pricelist_partnerinfo_search_view" model="ir.ui.view">
+            <field name="name">pricelist.partnerinfo.search</field>
+            <field name="model">pricelist.partnerinfo</field>
+            <field name="arch" type="xml">
+                <search string="Partnerinfo">
+                    <field name="name" />
+                    <field name="suppinfo_id" />
+                    <field name="product_tmpl_id" />
+                    <field name="product_code" />
+                    <field name="company_id" groups="base.group_multi_company" />
+                    <filter string="Customer" domain="[('type','=','customer')]" name="is_customer_filter"/>
+                    <filter string="Supplier" domain="[('type','=','supplier')]" name="is_supplier_filter"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Partner" icon="terp-partner"
+                            domain="[]" context="{'group_by':'partner'}" />
+                        <filter string="Product Template" domain="[]"
+                            name="group_product_tmpl_id" context="{'group_by':'product_tmpl_id'}" />
+                        <separator />
+                        <filter string="Type" domain="[]"
+                            context="{'group_by':'type'}" />
+                        <filter string="Company" domain="[]"
+                            name="group_company_id" context="{'group_by':'company_id'}"
+                            groups="base.group_multi_company" />
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <record id="pricelist_partnerinfo_action" model="ir.actions.act_window">
+            <field name="name">Partnerinfo</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">pricelist.partnerinfo</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_type">form</field>
+            <field name="search_view_id" ref="pricelist_partnerinfo_search_view" />
+            <field name="domain">[]</field>
+            <field name="context">{}
+            </field>
+            <field name="help" type="html">
+                <p class="oe_view_nocontent_create">
+                    Click to define a new pricelist.partnerinfo.
+                </p>
+            </field>
+        </record>
+
+        <menuitem id="pricelist_partnerinfo_sale_menu" parent="base.menu_product"
+            action="pricelist_partnerinfo_action" sequence="50" />
+
+    </data>
+</openerp>

--- a/product_pricelist_partnerinfo/views/product_view.xml
+++ b/product_pricelist_partnerinfo/views/product_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="product_template_form_view">
+            <field name="name">product.template.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_only_form_view" />
+            <field name="arch" type="xml">
+                <div name="buttons" position="inside">
+                    <button class="oe_stat_button" name="open_related_partnerinfo"
+                        icon="fa-money" type="object" string="Product Partnerinfo">
+                    </button>
+                </div>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_product_form_view">
+            <field name="name">product.product.form</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view" />
+            <field name="arch" type="xml">
+                <div name="buttons" position="inside">
+                    <button class="oe_stat_button" name="open_related_partnerinfo"
+                        icon="fa-money" type="object" string="Product Partnerinfo">
+                    </button>
+                </div>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_pricelist_partnerinfo/__init__.py
+++ b/purchase_pricelist_partnerinfo/__init__.py
@@ -1,0 +1,17 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################

--- a/purchase_pricelist_partnerinfo/__openerp__.py
+++ b/purchase_pricelist_partnerinfo/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    "name": "Product pricelist partnerinfo - Purchase extension",
+    "version": "1.0",
+    "depends": [
+        "product_pricelist_partnerinfo",
+        "purchase",
+    ],
+    "author": "OdooMRP team",
+    "website": "http://www.odoomrp.com",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <ajuaristio@gmail.com>"
+    ],
+    "category": "Hidden/Dependency",
+    "summary": "",
+    "data": [
+        "views/pricelist_partnerinfo_view.xml"
+    ],
+    "installable": True,
+    "auto_install": True,
+}

--- a/purchase_pricelist_partnerinfo/views/pricelist_partnerinfo_view.xml
+++ b/purchase_pricelist_partnerinfo/views/pricelist_partnerinfo_view.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <menuitem id="pricelist_partnerinfo_purchase_menu" parent="purchase.menu_procurement_management_product"
+            action="product_pricelist_partnerinfo.pricelist_partnerinfo_action" sequence="50" />
+
+    </data>
+</openerp>


### PR DESCRIPTION
- Añadir en menú una nueva entrada que tire contra la tabla pricelist-partnerinfo
  - En el tree deberá mostrar todos los campos suyos (tree editable para entrada rápida de precios y cantidades)
  - Campo related de supplierinfo: partner, tipo, template, cod producto
- Añadir filtros y agrupaciones por campos related de supplierinfo
- Desde ficha producto añadir shorcut que lleve a esta tabla filtrado por el producto desde el que navegamos.  (mas flexible que añadir one2many en solapa)
