### PR TITLE
[IMP] show the removal date in transfers

### DIFF
--- a/product_expiry_ext/wizard/stock_transfer_details.py
+++ b/product_expiry_ext/wizard/stock_transfer_details.py
@@ -9,4 +9,4 @@ from openerp import fields, models
 class TransferDetailsItems(models.TransientModel):
     _inherit = 'stock.transfer_details_items'
 
-    life_date = fields.Datetime(string='Life Date', related='lot_id.life_date')
+    removal_date = fields.Datetime(string='Removal Date', related='lot_id.removal_date')

--- a/product_expiry_ext/wizard/stock_transfer_details_view.xml
+++ b/product_expiry_ext/wizard/stock_transfer_details_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="stock.view_stock_enter_transfer_details" />
             <field name="arch" type="xml">
                 <field name="lot_id" position="after">
-                    <field name="life_date" />
+                    <field name="removal_date" />
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Of the four dates recorded on prodlots, the removal date is the most meaninful in the generic case, because this is the date that the scheduler uses to enforce FEFO warehouse rules.
The Life date on the other hand is only meaningful in indistries with very strict sanitary rules. Many industries even in agro would not use us but use best-before date instead.
