### PR TITLE
[ADD] stock_picking_customer_ref

### DIFF
--- a/stock_picking_customer_ref/README.rst
+++ b/stock_picking_customer_ref/README.rst
@@ -1,0 +1,15 @@
+Stock picking customer reference
+================================
+
+This module displays in the pickings, the sale reference/description, also
+allows you to filter and search for this new field.
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com
+* Ana Juaristi <ajuaristo@gmail.com>
+* Mikel Arregi <mikelarregi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/stock_picking_customer_ref/__init__.py
+++ b/stock_picking_customer_ref/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models

--- a/stock_picking_customer_ref/__openerp__.py
+++ b/stock_picking_customer_ref/__openerp__.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c)
+#    2015 Serv. Tec. Avanzados - Pedro M. Baeza (http://www.serviciosbaeza.com)
+#    2015 AvanzOsc (http://www.avanzosc.es)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Stock Picking Customer Ref",
+    'version': "1.0",
+    "author": "OdooMRP team",
+    'website': "http://www.odoomrp.com",
+    'category': 'Warehouse Management',
+    "depends": ["sale",
+                "stock",
+                "sale_stock"
+                ],
+    'data': ["views/stock_picking_view.xml"],
+    "installable": True,
+}

--- a/stock_picking_customer_ref/i18n/es.po
+++ b/stock_picking_customer_ref/i18n/es.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_picking_customer_ref
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-03-03 15:53+0000\n"
+"PO-Revision-Date: 2015-03-03 16:54+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: stock_picking_customer_ref
+#: view:stock.picking:stock_picking_customer_ref.view_picking_internal_search_inh_customerinfo
+msgid "Client order reference"
+msgstr "Referencia pedido cliente"
+
+#. module: stock_picking_customer_ref
+#: view:stock.picking:stock_picking_customer_ref.view_picking_internal_search_inh_customerinfo
+msgid "Origin"
+msgstr "Origen"
+
+#. module: stock_picking_customer_ref
+#: model:ir.model,name:stock_picking_customer_ref.model_stock_picking
+msgid "Picking List"
+msgstr "Albarán"
+
+#. module: stock_picking_customer_ref
+#: field:stock.picking,client_order_ref:0
+msgid "Sale Reference/Description"
+msgstr "Referencia/Descripción venta"
+

--- a/stock_picking_customer_ref/i18n/stock_picking_customer_ref.pot
+++ b/stock_picking_customer_ref/i18n/stock_picking_customer_ref.pot
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_picking_customer_ref
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-03-03 15:53+0000\n"
+"PO-Revision-Date: 2015-03-03 15:53+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_picking_customer_ref
+#: view:stock.picking:stock_picking_customer_ref.view_picking_internal_search_inh_customerinfo
+msgid "Client order reference"
+msgstr ""
+
+#. module: stock_picking_customer_ref
+#: view:stock.picking:stock_picking_customer_ref.view_picking_internal_search_inh_customerinfo
+msgid "Origin"
+msgstr ""
+
+#. module: stock_picking_customer_ref
+#: model:ir.model,name:stock_picking_customer_ref.model_stock_picking
+msgid "Picking List"
+msgstr ""
+
+#. module: stock_picking_customer_ref
+#: field:stock.picking,client_order_ref:0
+msgid "Sale Reference/Description"
+msgstr ""
+

--- a/stock_picking_customer_ref/models/__init__.py
+++ b/stock_picking_customer_ref/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import stock_picking

--- a/stock_picking_customer_ref/models/stock_picking.py
+++ b/stock_picking_customer_ref/models/stock_picking.py
@@ -7,7 +7,7 @@ from openerp import fields, models, api
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
-    
+
     @api.one
     @api.depends('group_id', 'sale_id', 'sale_id.client_order_ref')
     def _calculate_client_order_ref(self):

--- a/stock_picking_customer_ref/models/stock_picking.py
+++ b/stock_picking_customer_ref/models/stock_picking.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import fields, models, api
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+    
+    @api.one
+    @api.depends('group_id', 'sale_id', 'sale_id.client_order_ref')
+    def _calculate_client_order_ref(self):
+        sale_obj = self.env['sale.order']
+        self.client_order_ref = ''
+        if self.group_id:
+            cond = [('procurement_group_id', '=', self.group_id.id)]
+            sale = sale_obj.search(cond, limit=1)
+            self.client_order_ref = sale.client_order_ref
+
+    client_order_ref = fields.Char(
+        string="Sale Reference/Description",
+        compute="_calculate_client_order_ref", store=True)

--- a/stock_picking_customer_ref/views/stock_picking_view.xml
+++ b/stock_picking_customer_ref/views/stock_picking_view.xml
@@ -18,6 +18,9 @@
                 <field name="partner_id" position="after">
                     <field name="client_order_ref" attrs="{'invisible':[('client_order_ref', '=', False)]}" />
                 </field>
+                <field name="group_id" position="after">
+                    <field name="sale_id" attrs="{'invisible':[('sale_id', '=', False)]}" />
+                </field>
             </field>
         </record>
         <record model="ir.ui.view" id="view_picking_internal_search_inh_customerinfo">

--- a/stock_picking_customer_ref/views/stock_picking_view.xml
+++ b/stock_picking_customer_ref/views/stock_picking_view.xml
@@ -1,0 +1,37 @@
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="vpicktree_inh_customerinfo">
+            <field name="name">vpicktree.inh.customerinfo</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.vpicktree" />
+            <field name="arch" type="xml">
+                <field name="partner_id" position="after">
+                    <field name="client_order_ref" />
+                </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_picking_form_inh_customerinfo">
+            <field name="name">view.picking.form.inh.customerinfo</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_form" />
+            <field name="arch" type="xml">
+                <field name="partner_id" position="after">
+                    <field name="client_order_ref" attrs="{'invisible':[('client_order_ref', '=', False)]}" />
+                </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_picking_internal_search_inh_customerinfo">
+            <field name="name">view.picking.internal.search.inh.customerinfo</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_internal_search" />
+            <field name="arch" type="xml">
+                <field name="partner_id" position="after">
+                    <field name="client_order_ref" />
+                </field>
+                <filter string="Origin" position="before">
+                    <filter string="Client order reference" domain="[]" context="{'group_by':'client_order_ref'}"/>
+                </filter>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/stock_picking_customer_ref/views/stock_picking_view.xml
+++ b/stock_picking_customer_ref/views/stock_picking_view.xml
@@ -15,11 +15,8 @@
             <field name="model">stock.picking</field>
             <field name="inherit_id" ref="stock.view_picking_form" />
             <field name="arch" type="xml">
-                <field name="partner_id" position="after">
-                    <field name="client_order_ref" attrs="{'invisible':[('client_order_ref', '=', False)]}" />
-                </field>
                 <field name="group_id" position="after">
-                    <field name="sale_id" attrs="{'invisible':[('sale_id', '=', False)]}" />
+                    <field name="client_order_ref" attrs="{'invisible':[('client_order_ref', '=', False)]}" />
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Nuevo módulo solicitado en PR https://github.com/odoomrp/odoomrp-wip/pull/555.

Pedro... el campo no lo he podido poner como RELATED, ya que el campo "sale_id" no se graba en la BD. He hecho la prueba de ponerle RELATED al nuevo campo, pero no cogía el valor de "sale_id", así que este nuevo campo lo he puesto con un "compute".
