### PR TITLE
[ADD] stock_picking_wave_delete_operations_packages_info

### DIFF
--- a/stock_picking_wave_delete_operations_packages_info/README.rst
+++ b/stock_picking_wave_delete_operations_packages_info/README.rst
@@ -1,0 +1,14 @@
+Stock picking wave delete operations packages info info
+=======================================================
+
+This module deletes operations and packets of picking waves, when manual quants
+assignment is performed from any picking of picking wave.
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <ajuaristo@gmail.com>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/stock_picking_wave_delete_operations_packages_info/__init__.py
+++ b/stock_picking_wave_delete_operations_packages_info/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import wizard

--- a/stock_picking_wave_delete_operations_packages_info/__openerp__.py
+++ b/stock_picking_wave_delete_operations_packages_info/__openerp__.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Stock picking wave delete operations packages info',
+    'version': "1.0",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    'website': "http://www.odoomrp.com",
+    'category': 'Warehouse Management',
+    'depends': ["stock_picking_wave_package_info",
+                "stock_quant_manual_assign"
+                ],
+    'data': [],
+    'installable': True,
+    "auto_install": True,
+}

--- a/stock_picking_wave_delete_operations_packages_info/wizard/__init__.py
+++ b/stock_picking_wave_delete_operations_packages_info/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import assign_manual_quants

--- a/stock_picking_wave_delete_operations_packages_info/wizard/assign_manual_quants.py
+++ b/stock_picking_wave_delete_operations_packages_info/wizard/assign_manual_quants.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class AssignManualQuants(models.TransientModel):
+    _inherit = 'assign.manual.quants'
+
+    @api.multi
+    def assign_quants(self):
+        super(AssignManualQuants, self).assign_quants()
+        move = self.env['stock.move'].browse(self.env.context['active_id'])
+        if move.picking_id.wave_id:
+            move.picking_id.wave_id._delete_packages_information()
+        return {}


### PR DESCRIPTION
Nuevo módulo para borrar operaciones e información de paquetes en la agrupación de albaranes, cuando se realiza una asignación manual de quants.
