### PR TITLE
[ADD] mrp_production_no_split_finished_product_move: When most indica…

### DIFF
--- a/mrp_production_no_split_finished_product_move/README.rst
+++ b/mrp_production_no_split_finished_product_move/README.rst
@@ -1,0 +1,14 @@
+MRP production no split finished product move
+=============================================
+
+When most indicated material is produced in an OF, do not split in two
+movement.
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/mrp_production_no_split_finished_product_move/__init__.py
+++ b/mrp_production_no_split_finished_product_move/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import wizard

--- a/mrp_production_no_split_finished_product_move/__openerp__.py
+++ b/mrp_production_no_split_finished_product_move/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'MRP Production No Split Finished Product Move',
+    'version': "1.0",
+    'author': 'OdooMRP team,'
+              'AvanzOSC,'
+              'Serv. Tecnol. Avanzados - Pedro M. Baeza',
+    'website': "http://www.odoomrp.com",
+    "contributors": [
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+        ],
+    'category': 'Warehouse Management',
+    'depends': ['mrp',
+                'mrp_operations_extension'
+                ],
+    'data': [],
+    'installable': True,
+}

--- a/mrp_production_no_split_finished_product_move/wizard/__init__.py
+++ b/mrp_production_no_split_finished_product_move/wizard/__init__.py
@@ -1,0 +1,6 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import mrp_product_produce
+from . import mrp_work_order_produce

--- a/mrp_production_no_split_finished_product_move/wizard/mrp_product_produce.py
+++ b/mrp_production_no_split_finished_product_move/wizard/mrp_product_produce.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from openerp import api, models
+
+
+class MrpProductProduce(models.TransientModel):
+    _inherit = 'mrp.product.produce'
+
+    @api.multi
+    def do_produce(self):
+        self.ensure_one()
+        if self.mode == 'consume_produce':
+            production_id = self.env.context.get('active_id', False)
+            if production_id:
+                production = self.env['mrp.production'].browse(production_id)
+                move = production.move_created_ids.filtered(
+                    lambda x: x.product_id == production.product_id)
+                if move and self.product_qty > move[0].product_uom_qty:
+                    move[0].write({'product_uom_qty': self.product_qty})
+        return super(MrpProductProduce, self).do_produce()

--- a/mrp_production_no_split_finished_product_move/wizard/mrp_work_order_produce.py
+++ b/mrp_production_no_split_finished_product_move/wizard/mrp_work_order_produce.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from openerp import api, models
+
+
+class MrpWorkOrderProduce(models.TransientModel):
+    _inherit = 'mrp.work.order.produce'
+
+    @api.multi
+    def do_produce(self):
+        self.ensure_one()
+        work_line = self.env['mrp.production.workcenter.line'].browse(
+            self.env.context.get("active_id"))
+        move = work_line.production_id.move_created_ids.filtered(
+            lambda x: x.product_id == work_line.production_id.product_id)
+        if move and self.product_qty > move[0].product_uom_qty:
+            move[0].write({'product_uom_qty': self.product_qty})
+        return super(MrpWorkOrderProduce, self).do_produce()
+
+    @api.multi
+    def do_consume_produce(self):
+        self.ensure_one()
+        work_line = self.env['mrp.production.workcenter.line'].browse(
+            self.env.context.get("active_id"))
+        move = work_line.production_id.move_created_ids.filtered(
+            lambda x: x.product_id == work_line.production_id.product_id)
+        if move and self.product_qty > move[0].product_uom_qty:
+            move[0].write({'product_uom_qty': self.product_qty})
+        return super(MrpWorkOrderProduce, self).do_consume_produce()


### PR DESCRIPTION
…ted material is produced in an OF, do not split in two movement.

Nuevo módulo solicitado en la reclamación  Reclamación CLM0284-Crea demasiados tests de calidad (split de stock.move en producto a producir en la OF cuando se produce más cantidad que la de la OF).
Especificación técnica:
Cuando en una OF se produce más material del indicado a producir, en el último movimiento no hacer split en 2 del movimiento, sino generar un único movimiento con la cantidad correcta que al ser realizado creará un único quant.
