### PR TITLE
[ADD] stock_picking_to_invoice_when_cancel_invoice: When an invoice i…

### DIFF
--- a/stock_picking_to_invoice_when_cancel_invoice/README.rst
+++ b/stock_picking_to_invoice_when_cancel_invoice/README.rst
@@ -1,0 +1,16 @@
+Stock picking to invoice when cancel invoice
+============================================
+
+With this module when an invoice is canceled, it offers picking as
+"To be invoiced".
+If an invoice is deleted, It validates that the picking is in the status
+"Cancelled".
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/stock_picking_to_invoice_when_cancel_invoice/__init__.py
+++ b/stock_picking_to_invoice_when_cancel_invoice/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models

--- a/stock_picking_to_invoice_when_cancel_invoice/__openerp__.py
+++ b/stock_picking_to_invoice_when_cancel_invoice/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Stock Picking To Invoice When Cancel Invoice',
+    'version': "1.0",
+    'author': 'OdooMRP team,'
+              'AvanzOSC,'
+              'Serv. Tecnol. Avanzados - Pedro M. Baeza',
+    'website': "http://www.odoomrp.com",
+    "contributors": [
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+        ],
+    'category': 'Sales Management',
+    'depends': ['stock',
+                'account'
+                ],
+    'data': [],
+    'installable': True,
+}

--- a/stock_picking_to_invoice_when_cancel_invoice/i18n/es.po
+++ b/stock_picking_to_invoice_when_cancel_invoice/i18n/es.po
@@ -1,0 +1,28 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_picking_to_invoice_when_cancel_invoice
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-17 09:44+0000\n"
+"PO-Revision-Date: 2015-07-17 11:45+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: stock_picking_to_invoice_when_cancel_invoice
+#: code:addons/stock_picking_to_invoice_when_cancel_invoice/models/account_invoice.py:17
+#, python-format
+msgid "Before deleting invoice should cancel the picking: %s"
+msgstr "Antes de borrar la factura debe cancelar el albarán: %s"
+
+#. module: stock_picking_to_invoice_when_cancel_invoice
+#: model:ir.model,name:stock_picking_to_invoice_when_cancel_invoice.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+

--- a/stock_picking_to_invoice_when_cancel_invoice/i18n/stock_picking_to_invoice_when_cancel_invoice.pot
+++ b/stock_picking_to_invoice_when_cancel_invoice/i18n/stock_picking_to_invoice_when_cancel_invoice.pot
@@ -1,0 +1,28 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_picking_to_invoice_when_cancel_invoice
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-17 09:44+0000\n"
+"PO-Revision-Date: 2015-07-17 09:44+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_picking_to_invoice_when_cancel_invoice
+#: code:addons/stock_picking_to_invoice_when_cancel_invoice/models/account_invoice.py:17
+#, python-format
+msgid "Before deleting invoice should cancel the picking: %s"
+msgstr ""
+
+#. module: stock_picking_to_invoice_when_cancel_invoice
+#: model:ir.model,name:stock_picking_to_invoice_when_cancel_invoice.model_account_invoice
+msgid "Invoice"
+msgstr ""
+

--- a/stock_picking_to_invoice_when_cancel_invoice/models/__init__.py
+++ b/stock_picking_to_invoice_when_cancel_invoice/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import account_invoice

--- a/stock_picking_to_invoice_when_cancel_invoice/models/account_invoice.py
+++ b/stock_picking_to_invoice_when_cancel_invoice/models/account_invoice.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api, exceptions, _
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.multi
+    def unlink(self):
+        for invoice in self:
+            cond = [('name', '=', invoice.origin)]
+            picking = self.env['stock.picking'].search(cond)
+            if picking and picking.state != 'cancel':
+                raise exceptions.Warning(_('Before deleting invoice should'
+                                           ' cancel the picking: %s')
+                                         % invoice.origin)
+        return super(AccountInvoice, self).unlink()
+
+    @api.multi
+    def action_cancel(self):
+        res = super(AccountInvoice, self).action_cancel()
+        for invoice in self:
+            cond = [('name', '=', invoice.origin)]
+            picking = self.env['stock.picking'].search(cond)
+            if picking:
+                picking.write({'invoice_state': '2binvoiced'})
+        return res


### PR DESCRIPTION
…s canceled, it offers picking as "To be invoiced".

Antes de eliminar una factura, validar que su correspondiente albarán este cancelado. Cuando se cancela una factura, poner a su correspondiente albarán "Para ser facturado".
Este nuevo requerimiento lo ha solicitado Ana en la reclamación CLM0338-vovler atrás albaranes facturados cuando se elimina o cancela la fra.
