### PR TITLE
[ADD] mrp_production_unreserve_movements: New button "Unreserve".

### DIFF
--- a/mrp_production_unreserve_movements/README.rst
+++ b/mrp_production_unreserve_movements/README.rst
@@ -1,0 +1,18 @@
+MRP production unreserve movements
+==================================
+
+When the state of the manufacturing order is not "new", or "cancelled", or
+"done", "Check Availability", and "Force Reservation" buttons will be
+displayed. The new button ""Unreserve"" will also be displayed.
+
+These buttons will be shown in the work order, where the state is not
+"cancelled", or "done".
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/mrp_production_unreserve_movements/__init__.py
+++ b/mrp_production_unreserve_movements/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models

--- a/mrp_production_unreserve_movements/__openerp__.py
+++ b/mrp_production_unreserve_movements/__openerp__.py
@@ -1,0 +1,39 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'MRP Production Unreserve Movements',
+    'version': "1.0",
+    'author': 'OdooMRP team,'
+              'AvanzOSC,'
+              'Serv. Tecnol. Avanzados - Pedro M. Baeza',
+    'website': "http://www.odoomrp.com",
+    "contributors": [
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+        ],
+    'category': 'Manufacturing',
+    'depends': ['mrp',
+                'mrp_operations',
+                'mrp_operations_extension'
+                ],
+    'data': ["views/mrp_production_view.xml",
+             "views/mrp_production_workcenter_line_view.xml",
+             ],
+    'installable': True,
+}

--- a/mrp_production_unreserve_movements/i18n/es.po
+++ b/mrp_production_unreserve_movements/i18n/es.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_production_unreserve_movements
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-21 14:55+0000\n"
+"PO-Revision-Date: 2015-07-21 16:57+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: mrp_production_unreserve_movements
+#: model:ir.model,name:mrp_production_unreserve_movements.model_mrp_production
+msgid "Manufacturing Order"
+msgstr "Órden de producción"
+
+#. module: mrp_production_unreserve_movements
+#: view:mrp.production:mrp_production_unreserve_movements.mrp_production_form_view_inh_unreserve
+#: view:mrp.production.workcenter.line:mrp_production_unreserve_movements.workcenter_line_form_view_inh_unreserve
+msgid "Unreserve"
+msgstr "Anular reserva"
+
+#. module: mrp_production_unreserve_movements
+#: model:ir.model,name:mrp_production_unreserve_movements.model_mrp_production_workcenter_line
+msgid "Work Order"
+msgstr "Orden de trabajo"
+

--- a/mrp_production_unreserve_movements/i18n/mrp_production_unreserve_movements.pot
+++ b/mrp_production_unreserve_movements/i18n/mrp_production_unreserve_movements.pot
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_production_unreserve_movements
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-21 14:55+0000\n"
+"PO-Revision-Date: 2015-07-21 14:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mrp_production_unreserve_movements
+#: model:ir.model,name:mrp_production_unreserve_movements.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: mrp_production_unreserve_movements
+#: view:mrp.production:mrp_production_unreserve_movements.mrp_production_form_view_inh_unreserve
+#: view:mrp.production.workcenter.line:mrp_production_unreserve_movements.workcenter_line_form_view_inh_unreserve
+msgid "Unreserve"
+msgstr ""
+
+#. module: mrp_production_unreserve_movements
+#: model:ir.model,name:mrp_production_unreserve_movements.model_mrp_production_workcenter_line
+msgid "Work Order"
+msgstr ""
+

--- a/mrp_production_unreserve_movements/models/__init__.py
+++ b/mrp_production_unreserve_movements/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import mrp_production

--- a/mrp_production_unreserve_movements/models/mrp_production.py
+++ b/mrp_production_unreserve_movements/models/mrp_production.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, fields, api
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    @api.one
+    @api.depends('state', 'move_lines.state')
+    def _show_buttons(self):
+        self.show_check_availability = False
+        self.show_force_reservation = False
+        if self.state not in ('draft', 'cancel', 'done'):
+            moves = self.move_lines.filtered(
+                lambda x: x.state in ('waiting', 'confirmed') and
+                x.work_order.state not in ('cancel', 'done'))
+            if moves:
+                self.show_check_availability = True
+                self.show_force_reservation = True
+
+    @api.one
+    @api.depends('move_lines.state')
+    def _show_unreserve(self):
+        self.show_unreserve = False
+        moves = self.move_lines.filtered(
+            lambda x: x.state == 'assigned' and
+            x.work_order.state not in ('cancel', 'done'))
+        if moves:
+            self.show_unreserve = True
+
+    show_check_availability = fields.Boolean(
+        string='Show check availability button', compute='_show_buttons')
+    show_force_reservation = fields.Boolean(
+        string='Show force reservation button', compute='_show_buttons')
+    show_unreserve = fields.Boolean(
+        string='Show unreserve button', compute='_show_unreserve')
+
+    @api.multi
+    def button_unreserve(self):
+        moves = self.move_lines.filtered(lambda x: x.state == 'assigned' and
+                                         x.work_order.state == 'draft')
+        return moves.do_unreserve()
+
+
+class MrpProductionWorkcenterLine(models.Model):
+    _inherit = 'mrp.production.workcenter.line'
+
+    @api.one
+    @api.depends('state', 'production_id.move_lines.state')
+    def _show_buttons(self):
+        self.show_check_availability = False
+        self.show_force_reservation = False
+        if self.state not in ('cancel', 'done'):
+            moves = self.production_id.move_lines.filtered(
+                lambda x: x.state in ('waiting', 'confirmed') and
+                x.work_order.id == self.id)
+            if moves:
+                self.show_check_availability = True
+                self.show_force_reservation = True
+
+    @api.one
+    @api.depends('production_id.move_lines.state')
+    def _show_unreserve(self):
+        self.show_unreserve = False
+        if self.state not in ('cancel', 'done'):
+            moves = self.production_id.move_lines.filtered(
+                lambda x: x.state == 'assigned' and
+                x.work_order.id == self.id)
+            if moves:
+                self.show_unreserve = True
+
+    show_check_availability = fields.Boolean(
+        string='Show check availability button', compute='_show_buttons')
+    show_force_reservation = fields.Boolean(
+        string='Show force reservation button', compute='_show_buttons')
+    show_unreserve = fields.Boolean(
+        string='Show unreserve button', compute='_show_unreserve')
+
+    @api.multi
+    def button_unreserve(self):
+        moves = self.production_id.move_lines.filtered(
+            lambda x: x.state == 'assigned' and
+            x.work_order.id == self.id)
+        return moves.do_unreserve()

--- a/mrp_production_unreserve_movements/views/mrp_production_view.xml
+++ b/mrp_production_unreserve_movements/views/mrp_production_view.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="mrp_production_form_view_inh_unreserve">
+            <field name="name">mrp.production.form.view.inh.unreserve</field>
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp.mrp_production_form_view" />
+            <field name="arch" type="xml">
+                <field name="date_planned" position="after">
+                    <field name="show_check_availability" invisible="1" />
+                    <field name="show_force_reservation" invisible="1" />
+                    <field name="show_unreserve" invisible="1" />
+                </field>
+                <button name="action_assign" position="attributes">
+                    <attribute name="states"></attribute>
+                    <attribute name="attrs">{'invisible':[('show_check_availability','=',False)]}</attribute>
+                </button>
+                <button name="force_production" position="attributes">
+                    <attribute name="states"></attribute>
+                    <attribute name="attrs">{'invisible':[('show_force_reservation','=',False)]}</attribute>
+                </button>
+                <button name="force_production" position="after">
+                    <button name="button_unreserve" string="Unreserve" type="object"
+                            attrs="{'invisible':[('show_unreserve', '=', False)]}"/>
+                </button>
+                <xpath expr="//field[@name='workcenter_lines']/form//field[@name='workcenter_id']" position="after">
+                    <field name="show_check_availability" invisible="1" />
+                    <field name="show_force_reservation" invisible="1" />
+                    <field name="show_unreserve" invisible="1" />
+                </xpath>
+                <xpath expr="//field[@name='workcenter_lines']/form//button[@string='Check Availability']" position="attributes">
+                    <attribute name="states"></attribute>
+                    <attribute name="attrs">{'invisible':[('show_check_availability','=',False)]}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='workcenter_lines']/form//button[@string='Check Availability']" position="after">
+                    <button name="button_unreserve" string="Unreserve" type="object"
+                            attrs="{'invisible':[('show_unreserve', '=', False)]}"/>
+                </xpath>
+                <xpath expr="//field[@name='workcenter_lines']/form//button[@name='force_assign']" position="attributes">
+                    <attribute name="states"></attribute>
+                    <attribute name="attrs">{'invisible':[('show_force_reservation','=',False)]}</attribute>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/mrp_production_unreserve_movements/views/mrp_production_workcenter_line_view.xml
+++ b/mrp_production_unreserve_movements/views/mrp_production_workcenter_line_view.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="mrp_production_workcenter_form_view_inh_unreserve">
+            <field name="name">mrp.production.workcenter.form.view.inh.unreserve</field>
+            <field name="model">mrp.production.workcenter.line</field>
+            <field name="inherit_id" ref="mrp_operations.mrp_production_workcenter_form_view_inherit" />
+            <field name="arch" type="xml">
+                <field name="sequence" position="after">
+                    <field name="show_check_availability" invisible="1"/>
+                    <field name="show_force_reservation" invisible="1"/>
+                    <field name="show_unreserve" invisible="1"/>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="workcenter_line_form_view_inh_unreserve">
+            <field name="name">workcenter.line.form.view.inh.unreserve</field>
+            <field name="model">mrp.production.workcenter.line</field>
+            <field name="inherit_id" ref="mrp_operations_extension.workcenter_line_inh_form_view" />
+            <field name="arch" type="xml">
+                <button name="action_assign" position="attributes">
+                    <attribute name="states"></attribute>
+                    <attribute name="attrs">{'invisible':[('show_check_availability','=',False)]}</attribute>
+                </button>
+                <button name="force_assign" position="attributes">
+                    <attribute name="states"></attribute>
+                    <attribute name="attrs">{'invisible':[('show_force_reservation','=',False)]}</attribute>
+                </button>
+                <button name="force_assign" position="after">
+                    <button name="button_unreserve" string="Unreserve" type="object"
+                            attrs="{'invisible':[('show_unreserve', '=', False)]}"/>
+                </button>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Nuevo módulo para cubrir el requerimiento solicitado en la reclamación CLM0359-No se puede comprobar disponibilidad una vez iniciada la OF.
1. En Ofs una vez iniciadas, no hay forma de eliminar reserva y volver a comprobar disponibilidad de los movimientos que quedan pendientes. Hay que ir uno a uno movimiento por movimiento. Sería necesario añadir un botón en la OF que sea "eliminar reserva" y otro "comprobar disponiblidad"(este ya existe pero debería aparecer visible en cualquier estado de la of) Ambos botones actuarían exactamente igual que actúan los botones de cabecera de un albarán.
2. En OTs pasa lo mismo. No hay botones para comprobar disponibilidad o eliminar reserva de todos los movimientos de la OT.
