### PR TITLE
[ADD] procurement_purchase_no_grouping: This module defined in the pr…

### DIFF
--- a/procurement_purchase_no_grouping/README.rst
+++ b/procurement_purchase_no_grouping/README.rst
@@ -1,7 +1,7 @@
 Procurement purchase no grouping
 ================================
-This module defined in the product category "boolean" field "Group on procured
-purchases".
+This module defines in the product category a boolean field called "Group on
+procured purchases".
 If this new field is checked, running the procurement acts like the standard
 way, adding the amount on existing line purchase order if the product and the
 UoM is the same, but if it is not checked, no grouping will be done, creating

--- a/procurement_purchase_no_grouping/README.rst
+++ b/procurement_purchase_no_grouping/README.rst
@@ -1,0 +1,18 @@
+Procurement purchase no grouping
+================================
+This module defined in the product category "boolean" field "Group on procured
+purchases".
+If this new field is checked, running the procurement acts like the standard
+way, adding the amount on existing line purchase order if the product and the
+UoM is the same, but if it is not checked, no grouping will be done, creating
+a new line each time.
+
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <ajuaristo@gmail.com>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/procurement_purchase_no_grouping/__init__.py
+++ b/procurement_purchase_no_grouping/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models

--- a/procurement_purchase_no_grouping/__openerp__.py
+++ b/procurement_purchase_no_grouping/__openerp__.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Procurement Purchase No Grouping",
+    "version": "1.0",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "website": "http://www.odoomrp.com",
+    "category": "Procurements",
+    "depends": ['purchase',
+                'procurement',
+                ],
+    "data": ['views/product_category_view.xml',
+             ],
+    "installable": True
+}

--- a/procurement_purchase_no_grouping/i18n/es.po
+++ b/procurement_purchase_no_grouping/i18n/es.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* procurement_purchase_no_grouping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-03 14:50+0000\n"
+"PO-Revision-Date: 2015-08-03 16:54+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: procurement_purchase_no_grouping
+#: help:product.category,group_on_procured_purchases:0
+msgid ""
+"If this new field is checked, running the procurement acts like the standard "
+"way, adding the amount on existing line purchase order if the product and "
+"the UoM is the same, but if it is not checked, no grouping will be done, "
+"creating a new line each time"
+msgstr ""
+"Si este nuevo campo está marcado, ejecutando el abastecimiento actúa como la "
+"manera estándar, añadiendo la cantidad a la línea de orden de compra "
+"existente, si el producto y la unidad de medida es el mismo, pero si no está "
+"marcado, no se hará ninguna agrupación, sino que se creará una nueva línea "
+"cada vez."
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
+msgid "Product Category"
+msgstr "Categoría de producto"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Línea pedido de compra"

--- a/procurement_purchase_no_grouping/i18n/procurement_purchase_no_grouping.pot
+++ b/procurement_purchase_no_grouping/i18n/procurement_purchase_no_grouping.pot
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* procurement_purchase_no_grouping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-03 14:49+0000\n"
+"PO-Revision-Date: 2015-08-03 14:49+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: procurement_purchase_no_grouping
+#: help:product.category,group_on_procured_purchases:0
+msgid "If this new field is checked, running the procurement acts like the standard way, adding the amount on existing line purchase order if the product and the UoM is the same, but if it is not checked, no grouping will be done, creating a new line each time"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_procurement_order
+msgid "Procurement"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+

--- a/procurement_purchase_no_grouping/models/__init__.py
+++ b/procurement_purchase_no_grouping/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import product_category
+from . import procurement_order
+from . import purchase_order_line

--- a/procurement_purchase_no_grouping/models/procurement_order.py
+++ b/procurement_purchase_no_grouping/models/procurement_order.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def make_po(self):
+        res = super(
+            ProcurementOrder, self.with_context(not_group=True)).make_po()
+        return res

--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, fields
+
+
+class ProductCategory(models.Model):
+    _inherit = 'product.category'
+
+    group_on_procured_purchases = fields.Boolean(
+        string='Group on procured purchases', default=True,
+        help='If this new field is checked, running the procurement acts like'
+        ' the standard way, adding the amount on existing line purchase order'
+        ' if the product and the UoM is the same, but if it is not checked, no'
+        ' grouping will be done, creating a new line each time')

--- a/procurement_purchase_no_grouping/models/purchase_order_line.py
+++ b/procurement_purchase_no_grouping/models/purchase_order_line.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def search(self, cr, uid, args, offset=0, limit=None, order=None,
+               context=None, count=False):
+        if context and context.get('not_group', False):
+            product_id = False
+            for arg in args:
+                if arg[0] == 'product_id':
+                    product_id = arg[2]
+                    break
+            if product_id:
+                product = self.pool['product.product'].browse(
+                    cr, uid, product_id, context=context)
+                if not product.categ_id.group_on_procured_purchases:
+                    return []
+        return super(PurchaseOrderLine, self).search(
+            cr, uid, args, offset=offset, limit=limit, order=order,
+            context=context, count=count)

--- a/procurement_purchase_no_grouping/views/product_category_view.xml
+++ b/procurement_purchase_no_grouping/views/product_category_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="product_category_form_view_inh_purchasenogroup" model="ir.ui.view" >
+            <field name="name">product.category.form.view.inh.purchasenogroup</field>
+            <field name="inherit_id" ref="product.product_category_form_view"/>
+            <field name="model">product.category</field>
+            <field name="arch" type="xml">
+                <field name="type" position="after">
+                    <field name="group_on_procured_purchases" />
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_line_with_delivery_service_info/README.rst
+++ b/purchase_line_with_delivery_service_info/README.rst
@@ -1,0 +1,15 @@
+Purchase line with delivery service info
+========================================
+
+When a purchase order line is created from a procurement order with a product
+that is a transport service, unit price as the value of "standard_price" of the
+service field will get.
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <ajuaristo@gmail.com>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/purchase_line_with_delivery_service_info/__init__.py
+++ b/purchase_line_with_delivery_service_info/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models

--- a/purchase_line_with_delivery_service_info/__openerp__.py
+++ b/purchase_line_with_delivery_service_info/__openerp__.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Purchase Line With Delivery Service Info",
+    "version": "1.0",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "website": "http://www.odoomrp.com",
+    "category": "Delivery",
+    "depends": ['delivery',
+                'procurement_purchase_no_grouping',
+                ],
+    "data": [],
+    "installable": True
+}

--- a/purchase_line_with_delivery_service_info/i18n/es.po
+++ b/purchase_line_with_delivery_service_info/i18n/es.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_line_with_delivery_service_info
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-14 13:53+0000\n"
+"PO-Revision-Date: 2015-07-14 15:53+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: purchase_line_with_delivery_service_info
+#: field:sale.order.line,delivery_standard_price:0
+msgid "Delivery cost price"
+msgstr "Precio coste transporte"
+
+#. module: purchase_line_with_delivery_service_info
+#: model:ir.model,name:purchase_line_with_delivery_service_info.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: purchase_line_with_delivery_service_info
+#: model:ir.model,name:purchase_line_with_delivery_service_info.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: purchase_line_with_delivery_service_info
+#: model:ir.model,name:purchase_line_with_delivery_service_info.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"
+

--- a/purchase_line_with_delivery_service_info/i18n/purchase_line_with_delivery_service_info.pot
+++ b/purchase_line_with_delivery_service_info/i18n/purchase_line_with_delivery_service_info.pot
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_line_with_delivery_service_info
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-14 13:52+0000\n"
+"PO-Revision-Date: 2015-07-14 13:52+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_line_with_delivery_service_info
+#: field:sale.order.line,delivery_standard_price:0
+msgid "Delivery cost price"
+msgstr ""
+
+#. module: purchase_line_with_delivery_service_info
+#: model:ir.model,name:purchase_line_with_delivery_service_info.model_procurement_order
+msgid "Procurement"
+msgstr ""
+
+#. module: purchase_line_with_delivery_service_info
+#: model:ir.model,name:purchase_line_with_delivery_service_info.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: purchase_line_with_delivery_service_info
+#: model:ir.model,name:purchase_line_with_delivery_service_info.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+

--- a/purchase_line_with_delivery_service_info/models/__init__.py
+++ b/purchase_line_with_delivery_service_info/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import sale_order
+from . import procurement_order

--- a/purchase_line_with_delivery_service_info/models/procurement_order.py
+++ b/purchase_line_with_delivery_service_info/models/procurement_order.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def write(self, values):
+        res = super(ProcurementOrder, self).write(values)
+        if 'purchase_line_id' in values:
+            for proc in self:
+                routes = proc.product_id.route_ids.filtered(
+                    lambda r: r.name in ('Make To Order', 'Buy'))
+                if (proc.sale_line_id and
+                    proc.sale_line_id.delivery_standard_price and
+                    proc.purchase_line_id and proc.product_id.type == 'service'
+                        and len(routes) == 2):
+                    name = proc.purchase_line_id.name
+                    name += ', ' + proc.origin + ', ' + str(proc.date_planned)
+                    proc.purchase_line_id.write(
+                        {'name': name,
+                         'price_unit':
+                         proc.sale_line_id.delivery_standard_price})
+        return res

--- a/purchase_line_with_delivery_service_info/models/sale_order.py
+++ b/purchase_line_with_delivery_service_info/models/sale_order.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, fields, api
+import openerp.addons.decimal_precision as dp
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def delivery_set(self):
+        super(SaleOrder, self.with_context(
+            delivery_cost_info=True)).delivery_set()
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    delivery_standard_price = fields.Float(
+        string='Delivery cost price',
+        digits_compute=dp.get_precision('Product Price'))
+
+    @api.model
+    def create(self, data):
+        if (self.env.context.get('delivery_cost_info', False) and
+                data.get('is_delivery', False)):
+            data['delivery_standard_price'] = (
+                self._get_delivery_standard_cost(data.get('order_id')))
+        return super(SaleOrderLine, self).create(data)
+
+    def _get_delivery_standard_cost(self, order_id):
+        total = 0
+        weight = 0
+        volume = 0
+        quantity = 0
+        total_delivery = 0.0
+        product_uom_obj = self.env['product.uom']
+        sale_obj = self.env['sale.order']
+        order = sale_obj.browse(order_id)
+        carrier = self.env['delivery.carrier'].browse(order.carrier_id.id)
+        grid = self.env['delivery.grid'].browse(
+            carrier.grid_get(order.partner_shipping_id.id))
+        for line in order.order_line:
+            if line.state == 'cancel':
+                continue
+            if line.is_delivery:
+                total_delivery += (
+                    line.price_subtotal + sale_obj._amount_line_tax(line))
+            if not line.product_id or line.is_delivery:
+                continue
+            q = product_uom_obj._compute_qty(
+                line.product_uom.id, line.product_uom_qty,
+                line.product_id.uom_id.id)
+            weight += (line.product_id.weight or 0.0) * q
+            volume += (line.product_id.volume or 0.0) * q
+            quantity += q
+        total = (order.amount_total or 0.0) - total_delivery
+        return self._get_delivery_standard_cost_from_grid(
+            grid, total, weight, volume, quantity)
+
+    def _get_delivery_standard_cost_from_grid(
+            self, grid, total, weight, volume, quantity):
+        delivery_standard_price = 0.0
+        price_dict = {'price': total, 'volume': volume, 'weight': weight,
+                      'wv': volume*weight, 'quantity': quantity}
+        for line in grid.line_ids:
+            test = eval(line.type+line.operator+str(line.max_value),
+                        price_dict)
+            if test:
+                if line.price_type == 'variable':
+                    delivery_standard_price = (
+                        line.standard_price * price_dict[line.variable_factor])
+                else:
+                    delivery_standard_price = line.standard_price
+                break
+        return delivery_standard_price


### PR DESCRIPTION
…oduct category "boolean" field "Group on procured purchases". If this new field is checked, running the procurement acts like the standard

way, adding the amount on existing line purchase order if the product and the UoM is the same, but if it is not checked, no grouping will be done, creating a new line each time.
[ADD] purchase_line_with_delivery_service_info: When a purchase order line is created from a procurement order with a product that is a transport service, unit price as the value of "standard_price" of the
service field will get.

Nuevos módulo para cubrir nuevos requerimientos solicitados en reclamación CLM0141-Autofactura de Transportes
