### PR TITLE
FIX mrp_show_related_attachment - initialize attachment with None

### DIFF
--- a/mrp_show_related_attachment/models/mrp_production.py
+++ b/mrp_show_related_attachment/models/mrp_production.py
@@ -12,7 +12,7 @@ class MrpProduction(models.Model):
     @api.one
     @api.depends('product_id')
     def _calc_production_attachments(self):
-        self.product_attachments = [(5)]
+        self.product_attachments = None
         if self.product_id:
             cond = [('res_model', '=', 'product.product'),
                     ('res_id', '=', self.product_id.id)]
@@ -33,7 +33,7 @@ class MrpProductionWorkcenterLine(models.Model):
     @api.one
     @api.depends('workcenter_id')
     def _calc_workcenter_line_attachments(self):
-        self.workcenter_attachments = [(5)]
+        self.workcenter_attachments = None
         if self.workcenter_id:
             cond = [('res_model', '=', 'mrp.workcenter'),
                     ('res_id', '=', self.workcenter_id.id)]


### PR DESCRIPTION
Creating a new MO or WO would trigger a wrong attachment before selecting the product or the work center. Please image attached:
<img width="857" alt="screen shot 2015-09-14 at 8 52 54 pm" src="https://cloud.githubusercontent.com/assets/7885477/9859918/36e76cf0-5b29-11e5-8b6d-a20b86fa01a3.png">
Initializing the product_attachment with None will fix the issue.
