### PR TITLE
[IMP] stock_picking_customer_ref: Remove field dependence "sale_id" t…

### DIFF
--- a/stock_picking_customer_ref/models/__init__.py
+++ b/stock_picking_customer_ref/models/__init__.py
@@ -2,4 +2,5 @@
 ##############################################################################
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
+from . import sale_order
 from . import stock_picking

--- a/stock_picking_customer_ref/models/sale_order.py
+++ b/stock_picking_customer_ref/models/sale_order.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.multi
+    def write(self, vals):
+        picking_obj = self.env['stock.picking']
+        res = super(SaleOrder, self).write(vals)
+        # The field "client_order_ref" of pickings, is a calculated field. It
+        # can not be put into the field dependence "sale_id".
+        for sale in self:
+            if (vals.get('client_order_ref', False) and
+                    sale.procurement_group_id):
+                cond = [('group_id', '=', sale.procurement_group_id.id)]
+                pickings = picking_obj.search(cond)
+                pickings.write({'client_order_ref':
+                                vals.get('client_order_ref')})
+        return res

--- a/stock_picking_customer_ref/models/stock_picking.py
+++ b/stock_picking_customer_ref/models/stock_picking.py
@@ -9,7 +9,7 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     @api.one
-    @api.depends('group_id', 'sale_id', 'sale_id.client_order_ref')
+    @api.depends('group_id')
     def _calculate_client_order_ref(self):
         sale_obj = self.env['sale.order']
         self.client_order_ref = ''

--- a/stock_picking_customer_ref/tests/__init__.py
+++ b/stock_picking_customer_ref/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_stock_picking_customer_ref

--- a/stock_picking_customer_ref/tests/test_stock_picking_customer_ref.py
+++ b/stock_picking_customer_ref/tests/test_stock_picking_customer_ref.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestStockPickingCustomerRef(common.TransactionCase):
+
+    def setUp(self):
+        super(TestStockPickingCustomerRef, self).setUp()
+        self.sale_model = self.env['sale.order']
+        self.picking_model = self.env['stock.picking']
+        product = self.env.ref('product.product_product_19')
+        sale_vals = {
+            'partner_id': self.env.ref('base.res_partner_2').id,
+            'partner_shipping_id': self.env.ref('base.res_partner_2').id,
+            'partner_invoice_id': self.env.ref('base.res_partner_2').id,
+            'pricelist_id': self.env.ref('product.list0').id}
+        sale_line_vals = {
+            'product_id': product.id,
+            'name': product.name,
+            'product_uos_qty': 1,
+            'product_uom': product.uom_id.id,
+            'price_unit': product.list_price}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+        self.sale_order.with_context(show_sale=True).action_button_confirm()
+
+    def test_stock_picking_customer_ref(self):
+        self.sale_order.client_order_ref = 'A-123321'
+        cond = [('origin', '=', self.sale_order.name)]
+        pickings = self.picking_model.search(cond)
+        self.assertNotEqual(
+            len(pickings), 0, 'It has not generated the picking  confirming'
+            ' the sale order')
+        for picking in pickings:
+            self.assertEqual(
+                picking.client_order_ref, self.sale_order.client_order_ref,
+                'Order ref of picking not equal client order ref or sale')


### PR DESCRIPTION
…o calculate the field "client_order_ref" of pickings.

Se ha quitado la dependencia al campo "sale_id" de albaranes, ya que no es un campo que se graba en la tabla. El módulo funcionaba bien, lo que pasa es que fallaban lo test.
