### PR TITLE
[IMP] mrp_production_unreserve_movements: no confirmar las ordenes que ya tengan productos planificados

### DIFF
--- a/mrp_production_unreserve_movements/models/mrp_production.py
+++ b/mrp_production_unreserve_movements/models/mrp_production.py
@@ -48,6 +48,15 @@ class MrpProduction(models.Model):
             return False
         return True
 
+    @api.multi
+    def action_confirm(self):
+        mo_to_confirm = self.filtered(lambda x: not x.product_lines or
+                                      not x.move_lines)
+        mo_no_confirm = self.filtered(lambda x: x.product_lines and
+                                      x.move_lines)
+        mo_no_confirm.write({'state': 'confirmed'})
+        return super(MrpProduction, mo_to_confirm).action_confirm()
+
 
 class MrpProductionWorkcenterLine(models.Model):
     _inherit = 'mrp.production.workcenter.line'


### PR DESCRIPTION
Había un bug, que cuando anulabas la reserva de una OF. Se duplicaban los componentes. Esto viene dado a que al pasar a estado confirmado se regeneran los componentes y los productos a producir. Para solucionar, en el caso de que haya product_lines y también haya componentes, no ejecuto el action_confirm.