### PR TITLE
[FIX] This module shall depend on stock.

### DIFF
--- a/product_pricelist_partnerinfo/__openerp__.py
+++ b/product_pricelist_partnerinfo/__openerp__.py
@@ -22,6 +22,7 @@
     "depends": [
         "product",
         "product_supplierinfo_for_customer",
+        "stock",
     ],
     "author": "OdooMRP team, "
               "AvanzOSC, "


### PR DESCRIPTION
This solves

> AttributeError: 'product.template' object has no attribute '_get_act_window_dict'